### PR TITLE
Enable/disable context menu

### DIFF
--- a/extension/content/nocontextmenu.js
+++ b/extension/content/nocontextmenu.js
@@ -1,0 +1,23 @@
+/**
+ * Reference to object storage.local.get
+ * @function StorageArea.get()  
+ * @param {Object} context_menu - retrive context_menu item from local storage
+ * area
+ * @returns {Promise} Promise containing object keys context_menu.disable and
+ * context_menu.enable
+ */
+let getContextMenu = browser.storage.local.get("context_disable");
+
+/**
+ * @callback Success callback arrow function
+ * @param {boolean} context_menu.disable - If true context menu is disable 
+ */
+getContextMenu.then((item) => {
+  if (item.context_disable) {
+    window.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+    }, false);
+    console.log("Context menu disabled");
+  }
+});
+

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,11 +2,18 @@
 	"manifest_version": 2,
 	"name": "Modern Kiosk",
 	"description": "Kiosk-like facility extension for modern browsers",
+	"homepage_url": "https://github.com/racketlogger/ModernKiosk",
 	"version": "0.9",
-	"permissions": ["menus", "tabs", "browserSettings", "storage"],
+	"permissions": ["menus", "activeTab", "browserSettings", "storage"],
 	"background": {
 		"scripts": ["mk_bg.js"]
 	},
+	"content_scripts": [
+		{
+			"matches": ["<all_urls>"],
+			"js": ["content/nocontextmenu.js"]
+		}
+	],
 	"icons": {
 		"48": "icons/mk.svg"
 	},

--- a/extension/mk_bg.js
+++ b/extension/mk_bg.js
@@ -1,8 +1,8 @@
 
-var kiosk_window = undefined;
+var kiosk_window;
 
 function closeAllWindows(wil) {
-  for (wi of wil) {
+  for (let wi of wil) {
     if (wi !== kiosk_window) {
       // console.log(`Closing window: ${wi.id}`);
       // console.log(wi.tabs.map((tab) => {return tab.url}));
@@ -33,8 +33,8 @@ function browseKiosk(url) {
 
 function modernKioskURL() {
   return browser.storage.local.get("kiosk_url").then(function(item) {
-    console.log('Items: ' + JSON.stringify(item))
-    return item.kiosk_url || "https://www.google.com/";
+    console.log('Items: ' + JSON.stringify(item));
+    return item.kiosk_url;
   });
 }
 
@@ -89,3 +89,22 @@ browser.windows.onFocusChanged.addListener((wid) => {
     );
   }
 });
+
+/**
+ * Set in storage.local the default config values when the add-on is installed
+ * Called when user install the add-on
+ * @function setDefaultConfig()
+ */
+function setDefaultConfig() {
+  browser.storage.local.set({
+    kiosk_url: "http://example.org/",
+    context_enable: true,
+    context_disable: false
+  });
+}
+
+/**
+ * Event fired when user install the add-on
+ */
+browser.runtime.onInstalled.addListener(setDefaultConfig);
+

--- a/extension/options.html
+++ b/extension/options.html
@@ -11,6 +11,22 @@
       <br>
       <br>
       <input type="text" id="mk_url" style="width: 80%">
+      <br>
+      <br>
+      <label>Enable context menu?</label>
+      <br>
+      <br>
+      <input type="radio" id="context_menu_enabled" name="context_menu">
+      <label for="context_menu_enabled">Enable</label>
+      <input type="radio" id="context_menu_disabled"
+      name="context_menu">
+      <label for="context_menu_disabled">Disable</label>
+      <br>
+      <small>WARNING: If you choose to disable the context menu this will affect all your browser.</small>
+      <br>
+      <small>HEADS-UP! Please reload your page or strike F5 to make the changes take place.</small>
+      <br>
+      <small>The first time you install the add-on the context menu will be enabled by default.</small>
   </section>
 
   <section>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,6 +1,8 @@
 function saveOptions(e) {
   browser.storage.local.set({
-    kiosk_url: document.querySelector("#mk_url").value
+    kiosk_url: document.querySelector("#mk_url").value,
+    context_enable: document.querySelector("#context_menu_enabled").checked,
+    context_disable: document.querySelector("#context_menu_disabled").checked
   });
   e.preventDefault();
 }
@@ -11,9 +13,14 @@ function restoreOptions() {
   //   document.querySelector("#managed-colour").innerText = res.colour;
   // });
 
-  var gettingItem = browser.storage.local.get('kiosk_url');
+  var gettingItem = browser.storage.local.get();
   gettingItem.then((res) => {
-    document.querySelector("#mk_url").value = res.kiosk_url || 'https://www.google.com';
+    let getURL = document.querySelector("#mk_url");
+    let getContextEnable  = document.querySelector("#context_menu_enabled");
+    let getContextDisable = document.querySelector("#context_menu_disabled");
+    getURL.value = res.kiosk_url;
+    getContextEnable.checked  = res.context_enable;
+    getContextDisable.checked = res.context_disable;
   });
 }
 


### PR DESCRIPTION
Hi,
This patch fix issue #7 . Please review the code.
The unique inconvenience is that <"all_urls"> isn't a good practice at all, but works fine. [https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Request_the_right_permissions#Avoid_host_permission_%3Call_urls%3E_if_you_can](url)
I got another solution but fail in Windows OS due the bug [https://bugzilla.mozilla.org/show_bug.cgi?id=1408996](url). This problem is fixed but not ported to Mozilla 67 yet.
