### PR TITLE
Start Firefox in Modern Kiosk mode (Full Screen Mode - Issue #6)

### DIFF
--- a/extension/mk_bg.js
+++ b/extension/mk_bg.js
@@ -99,12 +99,28 @@ function setDefaultConfig() {
   browser.storage.local.set({
     kiosk_url: "http://example.org/",
     context_enable: true,
-    context_disable: false
+    context_disable: false,
+    fullscreen_enable: false,
+    fullscreen_disable: true
   });
 }
+
+/**
+ * Enter in kiosk mode on startup if preference "fullscreen_enable"
+ * is set to true. Reference to object storage.local.get
+ * @function StorageArea.get()
+ * @param {Object} fullscreen_enable - retrive fullscreen_enable
+ * @returns {Promise} Promise containing object key fullscreen_enable
+ */
+let getOnStartupFullscreen = browser.storage.local.get("fullscreen_enable");
+getOnStartupFullscreen.then((item) => {
+  if (item.fullscreen_enable) {
+    modernKioskURL().then(url => startKiosk(url));
+    console.log("Full Screen mode on startup enabled");
+  }
+});
 
 /**
  * Event fired when user install the add-on
  */
 browser.runtime.onInstalled.addListener(setDefaultConfig);
-

--- a/extension/options.html
+++ b/extension/options.html
@@ -27,6 +27,22 @@
       <small>HEADS-UP! Please reload your page or strike F5 to make the changes take place.</small>
       <br>
       <small>The first time you install the add-on the context menu will be enabled by default.</small>
+      <br>
+      <br>
+      <label>Start Firefox in Kiosk Mode?</label>
+      <br>
+      <br>
+      <input type="radio" id="fullscreen_enabled" name="start_kiosk_mode">
+      <label for="fullscreen_enabled">Enable</label>
+      <input type="radio" id="fullscreen_disabled"
+      name="start_kiosk_mode">
+      <label for="fullscreen_disabled">Disable</label>
+      <br>
+      <small>WARNING: If you choose to enable Firefox startup in Kiosk mode, this will affect the first start of your browser.</small>
+      <br>
+      <small>HEADS-UP! Please close Firefox and start again to make the changes take place.</small>
+      <br>
+      <small>The first time you install this add-on this preference is set to "disable" by default.</small>
   </section>
 
   <section>

--- a/extension/options.js
+++ b/extension/options.js
@@ -2,7 +2,9 @@ function saveOptions(e) {
   browser.storage.local.set({
     kiosk_url: document.querySelector("#mk_url").value,
     context_enable: document.querySelector("#context_menu_enabled").checked,
-    context_disable: document.querySelector("#context_menu_disabled").checked
+    context_disable: document.querySelector("#context_menu_disabled").checked,
+    fullscreen_enable: document.querySelector("#fullscreen_enabled").checked,
+    fullscreen_disable: document.querySelector("#fullscreen_disabled").checked
   });
   e.preventDefault();
 }
@@ -16,11 +18,15 @@ function restoreOptions() {
   var gettingItem = browser.storage.local.get();
   gettingItem.then((res) => {
     let getURL = document.querySelector("#mk_url");
-    let getContextEnable  = document.querySelector("#context_menu_enabled");
-    let getContextDisable = document.querySelector("#context_menu_disabled");
+    let getContextEnable     = document.querySelector("#context_menu_enabled");
+    let getContextDisable    = document.querySelector("#context_menu_disabled");
+    let getFullscreenEnable  = document.querySelector("#fullscreen_enabled");
+    let getFullscreenDisable = document.querySelector("#fullscreen_disabled");
     getURL.value = res.kiosk_url;
-    getContextEnable.checked  = res.context_enable;
-    getContextDisable.checked = res.context_disable;
+    getContextEnable.checked     = res.context_enable;
+    getContextDisable.checked    = res.context_disable;
+    getFullscreenEnable.checked  = res.fullscreen_enable;
+    getFullscreenDisable.checked = res.fullscreen_disable;
   });
 }
 


### PR DESCRIPTION
Start Firefox in Kiosk mode.
Ability to start Firefox in Modern Kiosk mode, but no command line options (issue #6).
Command line option can be supplied by startup programs in whichever OS or batch/bash scripts process.

To test:
1) Package the extension.
2) Run the Nightly or Developer Edition version of Firefox or
3) Follow steps in [Test permission requests page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Test_permission_requests#Observe_or_verify_install_time_permission_requests)
4) Install your extension
5) Go to ModernKiosk preferences
6) Change the option Start Firefox in Kiosk mode to "Enable"
7) Close and start Firefox againg.
8) Observe that Firefox start in Full Screen mode with the page pre-defined in url option.

Optional test (If don't want to package)
1) Make a new clone or download a zip (of the fork hecaxmmx:master) to test in a temporary installation
2) Change lines (extension/mk_bg.js) and save:
    fullscreen_enable: false, to "true"
    fullscreen_disable: true to "false"
2) Got to about:debugging and click in button "Load temporary add-on"
3) See that Firefox is launched in kiosk mode with page "example.org"
