### PR TITLE
Improvements with EKC, password, and, notifications

### DIFF
--- a/extension/content/nocontextmenu.js
+++ b/extension/content/nocontextmenu.js
@@ -1,19 +1,47 @@
 /**
- * Reference to object storage.local.get
- * @function StorageArea.get()  
- * @param {Object} context_menu - retrive context_menu item from local storage
- * area
- * @returns {Promise} Promise containing object keys context_menu.disable and
- * context_menu.enable
+ * nocontextmenu.js
+ * @license
+ * This file is part of Modern Kiosk
+ *
+ * Copyright (C) 2018-2019 - RacketLogger
+ * Copyright (C) 2019 - Universidad de El Salvador
+ *
+ * Modern Kiosk is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Modern Kiosk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Modern Kiosk. If not, see <http://www.gnu.org/licenses/>.
  */
-let getContextMenu = browser.storage.local.get("context_disable");
+
+/**
+ * @file Content script injected in web pages to disable the context menu of
+ * the browser.
+ * @author Hector Castro
+ */
+
+/**
+ * @function StorageArea.get()
+ * @param {string|Object} context_menu - retrive context_menu item from local
+ * storage area.
+ * @returns {Promise} Promise containing object keys context_enable
+ */
+
+let getContextMenu = browser.storage.local.get("context_enable");
 
 /**
  * @callback Success callback arrow function
- * @param {boolean} context_menu.disable - If true context menu is disable 
+ * @param {boolean} item.context_enable - If false context menu is disable
+ * @event window#contextmenu
  */
 getContextMenu.then((item) => {
-  if (item.context_disable) {
+  if (item.context_enable === false) {
     window.addEventListener("contextmenu", (e) => {
       e.preventDefault();
     }, false);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,14 +4,19 @@
 	"description": "Kiosk-like facility extension for modern browsers",
 	"homepage_url": "https://github.com/racketlogger/ModernKiosk",
 	"version": "0.12",
-	"permissions": ["menus", "activeTab", "browserSettings", "storage"],
+	"permissions": ["menus", "tabs", "browserSettings", "storage", "notifications"],
 	"background": {
-		"scripts": ["mk_bg.js"]
+		"scripts": ["mk_bg.js", "mk_utils.js"]
 	},
 	"content_scripts": [
 		{
 			"matches": ["<all_urls>"],
-			"js": ["content/nocontextmenu.js"]
+			"js": [
+				"content/nocontextmenu.js",
+				"content/passwordmodal.js",
+				"content/notifications.js",
+				"content/listener.js"
+			]
 		}
 	],
 	"icons": {
@@ -25,5 +30,11 @@
 		"default_icon": {
 			"32": "icons/mk.svg"
 		}
-  }
+	},
+	"commands": {
+		"exit-kiosk-mode": {
+			"suggested_key": { "default": "Ctrl+Shift+U" },
+			"description": "Exit Modern Kiosk Mode"
+		}
+	}
 }

--- a/extension/mk_bg.js
+++ b/extension/mk_bg.js
@@ -1,17 +1,50 @@
+/**
+ * mk_bg.js
+ * @license
+ * This file is part of Modern Kiosk
+ *
+ * Copyright (C) 2018-2019 - RacketLogger
+ * Copyright (C) 2019 - Universidad de El Salvador
+ *
+ * Modern Kiosk is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Modern Kiosk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Modern Kiosk. If not, see <http://www.gnu.org/licenses/>.
+ */
 
-var kiosk_window;
+/**
+ * @file Background script for the web-extension performing the long-term
+ * operations.
+ * @requires mk_utils
+ * @author Carlos Puchol
+ * @author Hector Castro
+ */
 
-function closeAllWindows(wil) {
-  for (let wi of wil) {
-    if (wi !== kiosk_window) {
-      // console.log(`Closing window: ${wi.id}`);
-      // console.log(wi.tabs.map((tab) => {return tab.url}));
-      // uncomment before release
-      // browser.windows.remove(wi);
-    }
-  }
-}
+/**
+ * @global
+ * @description Variables declared as global.
+ * kiosk_window variable store the ID of the window open when app start
+ * the kiosk mode.
+ * kiosk_window_tabs store an array with tabs id for panel fullscreen window
+ * kiosk_mode variable store a boolean value to identificate if app stay in
+ * kiosk mode or not.
+ */
+let kiosk_window, kiosk_window_tabs, kiosk_mode;
 
+/**
+ * Start the Kiosk Mode
+ * @function startKiosk
+ * @param {string} url Uniform Resource Locator to display in Kiosk Mode.
+ * @description Assign data to global variables kiosk_window and kiosk_mode.
+ */
 function startKiosk(url) {
   console.log("Starting ModernKiosk with URL: " + url);
   browser.windows.create({
@@ -19,26 +52,60 @@ function startKiosk(url) {
     state: "fullscreen",
     type: "panel"
   }).then((winfo) => {
-    kiosk_window = winfo.id;
-    // close all other windows
-    browser.windows.getAll({ populate: true }).then(closeAllWindows);
+    // Test if something went wrong when user saved the password
+    const getPassword = browser.storage.local.get();
+    getPassword.then(async (item) => {
+      let message;
+      if (!item.password_stored && item.password_enable) {
+        browser.windows.onFocusChanged.removeListener(listenerFocusChanged);
+        browser.windows.onRemoved.removeListener(listenerOnRemoved);
+        message = "The preference 'enable optional password' is set to ";
+        message += "enabled, but password box is empty.\n"
+        message += "Please go back to Modern Kiosk preferences and save one.";
+        message += "Or disable the preference to start in Kiosk Mode.";
+        mkNotifications("no-password", message);
+        await browser.windows.remove(winfo.id);
+        throw new Error("No password stored. Kiosk mode cannot start");
+      } else {
+        // asign the id of the window and id of the tab opened as kiosk
+        kiosk_window = winfo.id;
+        kiosk_window_tabs = winfo.tabs.map((tab) => {return tab.id});
+        message = `Window created: ${winfo.id}. Tab: ${kiosk_window_tabs[0]}`;
+        console.log(message);
+        // asign boolean to test kiosk mode and non kiosk mode
+        kiosk_mode = true;
+      }
+    }).catch((error) => {
+      console.error(error.message);
+      browser.windows.onRemoved.addListener(listenerOnRemoved);
+      browser.windows.onFocusChanged.addListener(listenerFocusChanged);
+    });
   });
 }
 
+/**
+ * @deprecated Left here for debugging
+ * @function browseKiosk
+ * @param {string} url Uniform Resource Locator.
+ */
 function browseKiosk(url) {
   console.log("Browsing ModernKiosk with URL: " + url);
   browser.windows.create({ url: url }).then();
 }
 
-
+/**
+ * Get url form StorageArea and return a Promise
+ * @function modernKioskURL
+ * @returns {Promise}
+ */
 function modernKioskURL() {
-  return browser.storage.local.get("kiosk_url").then(function(item) {
+  return browser.storage.local.get("kiosk_url").then((item) => {
     console.log('Items: ' + JSON.stringify(item));
     return item.kiosk_url;
   });
 }
 
-// context menu to manage ModernKiosk
+/** Context menu to manage ModernKiosk */
 browser.menus.create({
   id: 'mk-preferences',
   title: "ModernKiosk preferences"
@@ -52,35 +119,114 @@ browser.menus.create({
   title: "Enter kiosk mode"
 });
 
+/**
+ * Display a menu in toolbar and context menu
+ * @callback modernKioskMenuSelect
+ * @param info Information about the item clicked and the context where the
+ * click happened.
+ * @param tab The details of the tab where the click took place.
+ */
 function modernKioskMenuSelect(info, tab) {
-  console.log(info);
+  let message;
+  let getCurrentWin = browser.windows.getCurrent({populate: true});
 
   if (info.menuItemId == 'mk-start') {
-    modernKioskURL().then(url => startKiosk(url));
+    getCurrentWin.then(windowInfo => {
+      if (kiosk_mode) {
+        message = "Modern Kiosk is already in Kiosk Mode";
+        mkToContentNotify(kiosk_window_tabs[0], message);
+        return;
+      } else if (windowInfo.state === "fullscreen") {
+        message = "You cannot start Kiosk Mode in full screen";
+        mkToContentNotify(tab.id, message);
+        return;
+      } else {
+        modernKioskURL().then(url => startKiosk(url));
+      }
+    });
   } else if (info.menuItemId == 'mk-preferences') {
-    browser.runtime.openOptionsPage().then();
+    if (kiosk_mode) {
+      message = "Work in progress, for the time being this option is disabled";
+      message += "from the Kiosk Mode.";
+      mkToContentNotify(kiosk_window_tabs[0], message);
+      return;
+    } else {
+      browser.runtime.openOptionsPage().then();
+    }
   } else if (info.menuItemId == 'mk-current-url') {
-    // Deprecated -- left here for debugging
+    /** @deprecated left here for debugging */
     modernKioskURL().then(url => browseKiosk(url));
-  } else if (info.menuItemId == 'mk-url' && /^http/.test(info.pageUrl)) {
-    browser.storage.local.set({ kiosk_url: info.pageUrl });
-    console.log(info.pageUrl);
+  } else if (info.menuItemId == 'mk-url') {
+    modernKioskURL().then(url => {
+      getCurrentWin.then(windowInfo => {
+        if (kiosk_mode) {
+          message = "Option not available in Kiosk Mode";
+          mkToContentNotify(kiosk_window_tabs[0], message);
+          return;
+        } else {
+          if (url === info.pageUrl) {
+            message = "This URL is already set as your current URL";
+            (windowInfo.state === "fullscreen")
+            ? mkToContentNotify(tab.id, message)
+            : mkNotifications("url-notification", message);
+            return;
+          } else if (/^about:/i.test(info.pageUrl)) {
+            message = "You cannot set 'about:*' URL protocol. "
+            message += "Please use http or https schema.\n"
+            message += "This could also happen if you have set the Mozilla"
+            message += " Firefox Start Page as your Home Page Preference.";
+            (windowInfo.state === "fullscreen")
+            ? mkToContentNotify(tab.id, message)
+            : mkNotifications("about-notification", message);
+            return;
+          } else if (/^http/.test(info.pageUrl)) {
+            message = `URL stored as kiosk URL: ${ info.pageUrl }`;
+            browser.storage.local.set({ kiosk_url: info.pageUrl });
+            (windowInfo.state === "fullscreen")
+            ? mkToContentNotify(tab.id, message)
+            : mkNotifications("storage-notification", message);
+          }
+        }
+      });
+    });
   }
 }
 
+/**
+ * Event fired when user do a right click in rounded-square icon in toolbar, or,
+ * when click on context menu
+ * @event browser#onClicked
+ */
 browser.menus.onClicked.addListener(modernKioskMenuSelect);
 
-browser.windows.onRemoved.addListener((wid) => {
-  if (wid === kiosk_window) {
-    console.log("Closed window: " + wid);
+/**
+ * Called when user try to close a window.
+ * @callback listenerOnRemoved
+ * @param {number} wid ID of the window that was closed.
+ */
+function listenerOnRemoved(wid) {
+    console.log(`Closed window: ${ wid }. Permission denied.`);
     modernKioskURL().then(url => startKiosk(url));
-  }
-});
+    console.log("Window reopened.");
+}
 
-browser.windows.onFocusChanged.addListener((wid) => {
-  console.log("Focus changed on window: " + wid);
-  console.log("MK window: " + kiosk_window);
-  if (kiosk_window && (wid === kiosk_window || wid === browser.windows.WINDOW_ID_NONE)) {
+/**
+ * Event fired when user try to close a window.
+ * @event browser#onRemoved
+ */
+browser.windows.onRemoved.addListener(listenerOnRemoved);
+
+/**
+ * Called when user try to change focus to window left behind.
+ * @callback listenerFocusChanged
+ * @param {number} wid ID of the newly focused window.
+ */
+function listenerFocusChanged(wid) {
+  console.log(`Focus changed on window: ${ wid }`);
+  console.log(`MK window: ${ kiosk_window }`);
+  if (kiosk_window &&
+      (wid === kiosk_window || wid === browser.windows.WINDOW_ID_NONE)
+  ) {
     browser.windows.update(
       kiosk_window, {
         focused: true,
@@ -88,32 +234,40 @@ browser.windows.onFocusChanged.addListener((wid) => {
       }
     );
   }
-});
+}
+
+/**
+ * Event fired when user try to change focus on window left behind.
+ * @event browser#onFocusChanged
+ */
+browser.windows.onFocusChanged.addListener(listenerFocusChanged);
 
 /**
  * Set in storage.local the default config values when the add-on is installed
- * Called when user install the add-on
- * @function setDefaultConfig()
+ * called when user install the add-on.
+ * @callback setDefaultConfig
  */
 function setDefaultConfig() {
-  browser.storage.local.set({
+let mkStorageArea = {
     kiosk_url: "http://example.org/",
     context_enable: true,
-    context_disable: false,
     fullscreen_enable: false,
-    fullscreen_disable: true
-  });
+    password_enable: false,
+    password_stored: false,
+    password: undefined
+  }
+  browser.storage.local.set(mkStorageArea);
 }
 
 /**
  * Enter in kiosk mode on startup if preference "fullscreen_enable"
- * is set to true. Reference to object storage.local.get
- * @function StorageArea.get()
- * @param {Object} fullscreen_enable - retrive fullscreen_enable
- * @returns {Promise} Promise containing object key fullscreen_enable
+ * is set to true. Reference to object storage.local.get.
+ * @callback arrow function
+ * @param {string|Object} item - retrive fullscreen_enable.
+ * @returns {Promise} Promise containing object key fullscreen_enable.
  */
-let getOnStartupFullscreen = browser.storage.local.get("fullscreen_enable");
-getOnStartupFullscreen.then((item) => {
+const getStorageFullScreen = browser.storage.local.get();
+getStorageFullScreen.then((item) => {
   if (item.fullscreen_enable) {
     modernKioskURL().then(url => startKiosk(url));
     console.log("Full Screen mode on startup enabled");
@@ -122,5 +276,87 @@ getOnStartupFullscreen.then((item) => {
 
 /**
  * Event fired when user install the add-on
+ * @event browser#onInstalled
  */
 browser.runtime.onInstalled.addListener(setDefaultConfig);
+
+/**
+ * Event fired when user strike EKC combination to exit Modern Kiosk.
+ * @event browser#onCommand
+ */
+browser.commands.onCommand.addListener(async (command) => {
+  try {
+    if (command === "exit-kiosk-mode") {
+      console.log("Exit Modern Kiosk Mode [Work in progress...]");
+      // remove Listeners for onFocusChanged and onRemoved
+      browser.windows.onFocusChanged.removeListener(listenerFocusChanged);
+      browser.windows.onRemoved.removeListener(listenerOnRemoved);
+      // asynchronous function awaiting all process to close windows
+      // needed for re-add the Listeners to onFocusChanged and onRemoved events
+      const getStorage = browser.storage.local.get();
+      await getStorage.then(async (item) => {
+        if (item.fullscreen_enable === false &&
+            item.password_enable === false
+        ) {
+          await browser.windows.remove(kiosk_window);
+          kiosk_mode = false;
+        } else if (item.fullscreen_enable === true &&
+            item.password_enable === false
+        ) {
+          await browser.windows.remove(kiosk_window);
+          kiosk_mode = false;
+        } else if (item.fullscreen_enable === true &&
+            item.password_enable === true
+        ) {
+          await browser.tabs.sendMessage(
+            kiosk_window_tabs[0],
+            {ask_kiosk_password: true}
+          ).then(async (response) => {
+            console.log("Message from the content script:");
+            let message;
+            if (!response.response) {
+              message = "You did not enter any password.\n";
+              message += "Or you're closed the password dialog.";
+              mkToContentNotify(kiosk_window_tabs[0], message);
+              throw new Error("User didn't enter password or canceled dialog");
+            } else if (response.response !== item.password) {
+              message = "Icorrect password!";
+              mkToContentNotify(kiosk_window_tabs[0], message);
+              throw new Error(`User populate: ${ message }`);
+            } else if (response.response === item.password) {
+              console.log("Password OK");
+              console.log("Exit Modern Kiosk Mode [Complete...]");
+              if (!response.preferences) {
+                let allWindows = browser.windows.getAll({ populate: true });
+                // close all windows if Firefox start in Kiosk Mode and
+                // password is enabled
+                await allWindows.then(async (wil) => {
+                  for (let wi of wil) {
+                    console.log(`Closing window: ${ wi.id }`);
+                    console.log(wi.tabs.map((tab) => {return tab.id}));
+                    await browser.windows.remove(wi.id);
+                  }
+                });
+              } else {
+                // close only Kiosk Window
+                await browser.windows.remove(kiosk_window);
+              }
+              kiosk_mode = false;
+            }
+          }).catch((error) => {
+            console.error(error.message);
+            // If user close window, disconnect message, here catch error and
+            // reopen the window
+            if (/^Error: Message manager disconnected/.test(error)) {
+              modernKioskURL().then(url => startKiosk(url));
+            }
+          });
+        }
+      });
+      // re-adding Listeners removed above
+      browser.windows.onRemoved.addListener(listenerOnRemoved);
+      browser.windows.onFocusChanged.addListener(listenerFocusChanged);
+    }
+  } catch (error) { console.error(`Closing failed: ${ error.message }`); }
+});
+

--- a/extension/options.html
+++ b/extension/options.html
@@ -4,53 +4,255 @@
   <head>
     <meta charset="utf-8">
   </head>
+  <style>
 
+button:disabled,
+button[disabled]{
+  border: 1px solid #999999;
+  background-color: #cccccc;
+  color: #666666;
+}
+
+/* Style to change icons on input type URL */
+  input[type=url] {
+    border-color: rgba(12, 12, 13, 0.2);
+    padding-right: 30px;
+    width: 80%;
+    background-image: url('icons/Globe.svg');
+    background-repeat: no-repeat;
+    background-size: 20px 20px;
+    background-position: right center;
+  }
+
+  input[type=url]:hover {
+    border-color: rgba(12, 12, 13, 0.3);
+    padding-right: 30px;
+    width: 80%;
+    background-image: url('icons/Globe.svg');
+    background-repeat: no-repeat;
+    background-size: 20px 20px;
+    background-position: right center;
+  }
+
+  input[type=url]:focus {
+    border-color: #0a84ff;
+    box-shadow: 0 0 0 1px #0a84ff, 0 0 0 4px rgba(10, 132, 255, 0.3);
+    padding-right: 30px;
+    width: 80%;
+    background-image: url('icons/Cancel.svg');
+    background-repeat: no-repeat;
+    background-size: 20px 20px;
+    background-position: right center;
+  }
+
+  input[type=url]:invalid {
+    border-color: #d70022;
+    box-shadow: 0 0 0 1px #d70022, 0 0 0 4px rgba(251, 0, 34, 0.3);
+    padding-right: 30px;
+    width: 80%;
+    background-image: url('icons/Globe.svg');
+    background-repeat: no-repeat;
+    background-size: 20px 20px;
+    background-position: right center;
+  }
+
+/* Style to change icons on input type password */
+  #mk_password, #confirm_password {
+    border-color: rgba(12, 12, 13, 0.2);
+    padding-right: 30px;
+    width: 50%;
+    background-image: url('icons/Hide.svg');
+    background-repeat: no-repeat;
+    background-size: 20px 20px;
+    background-position: right center;
+    font-family: "Courier New", "Lucida Console";
+  }
+
+  #mk_password:hover, #confirm_password:hover {
+    border-color: rgba(12, 12, 13, 0.3);
+    padding-right: 30px;
+    width: 50%;
+    background-image: url('icons/Hide.svg');
+    background-repeat: no-repeat;
+    background-size: 20px 20px;
+    background-position: right center;
+    font-family: "Courier New", "Lucida Console";
+  }
+
+  #mk_password:focus, #confirm_password:focus {
+    border-color: #0a84ff;
+    box-shadow: 0 0 0 1px #0a84ff, 0 0 0 4px rgba(10, 132, 255, 0.3);
+    padding-right: 30px;
+    width: 50%;
+    background-image: url('icons/Hide.svg');
+    background-repeat: no-repeat;
+    background-size: 20px 20px;
+    background-position: right center;
+    font-family: "Courier New", "Lucida Console";
+  }
+
+/* Taken from https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd */
+kbd {
+    background-color: #eee;
+    border-radius: 3px;
+    border: 1px solid #b4b4b4;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+    color: #333;
+    display: inline-block;
+    font-size: .85em;
+    font-weight: 700;
+    line-height: 1;
+    padding: 2px 4px;
+    white-space: nowrap;
+    }
+
+.alert {
+    color: #004085;
+    background-color: #cce5ff;
+    border-color: #b8daff;
+    position: relative;
+    padding: .75rem 1.25rem;
+    margin-bottom: 1rem;
+    border: 1px solid transparent;
+    border-radius: .25rem;
+}
+
+/* If necessary some simple icons
+ * How to use: <span class="icon icon-warn"></span>
+ */
+.icon {
+    display: inline-block;
+    font-size: 22px;
+    font-weight: bold;
+    color: rgba(12, 12, 13, .8);
+    }
+
+/* Hexadecimal UTF-8 icons */
+.icon-note:after { content: "\2633"; }
+.icon-warn:after { content: "\26a0"; }
+.icon-info:after { content: "\24d8"; }
+
+/* Photon icons */
+.icon-preferences {
+    background-position: 0 0;
+    width: 16px; height: 16px;
+    background: url('icons/Preferences.svg') no-repeat top left;
+    }
+
+  </style>
 <body>
-  <section>
-      <label>ModernKiosk URL</label>
-      <br>
-      <br>
-      <input type="text" id="mk_url" style="width: 80%">
-      <br>
-      <br>
-      <label>Enable context menu?</label>
-      <br>
-      <br>
-      <input type="radio" id="context_menu_enabled" name="context_menu">
-      <label for="context_menu_enabled">Enable</label>
-      <input type="radio" id="context_menu_disabled"
-      name="context_menu">
-      <label for="context_menu_disabled">Disable</label>
-      <br>
-      <small>WARNING: If you choose to disable the context menu this will affect all your browser.</small>
-      <br>
-      <small>HEADS-UP! Please reload your page or strike F5 to make the changes take place.</small>
-      <br>
-      <small>The first time you install the add-on the context menu will be enabled by default.</small>
-      <br>
-      <br>
-      <label>Start Firefox in Kiosk Mode?</label>
-      <br>
-      <br>
-      <input type="radio" id="fullscreen_enabled" name="start_kiosk_mode">
-      <label for="fullscreen_enabled">Enable</label>
-      <input type="radio" id="fullscreen_disabled"
-      name="start_kiosk_mode">
-      <label for="fullscreen_disabled">Disable</label>
-      <br>
-      <small>WARNING: If you choose to enable Firefox startup in Kiosk mode, this will affect the first start of your browser.</small>
-      <br>
-      <small>HEADS-UP! Please close Firefox and start again to make the changes take place.</small>
-      <br>
-      <small>The first time you install this add-on this preference is set to "disable" by default.</small>
-  </section>
-
-  <section>
+<form>
+  <div class="browser-style">
+    <header class="panel-section panel-section-header">
+    <div class="icon-section-header"><img src="icons/Preferences.svg"/></div>
+    <div class="text-section-header">General Preferences</div>
+    </header>
+    <br>
+    <br>
+    <label for="mk_url">ModernKiosk URL</label>
+    <br>
+    <input type="url" name="mk_url" id="mk_url"
+    placeholder="http://example.com" pattern="http.*" size="30" required>
+    <br>
+    <small>(Enter an http:// or https:// URL)</small>
+    <br>
+    <br>
+    <label>Enable context menu?</label>
+    <br>
+    <br>
+    <input type="radio" id="context_menu_enabled" name="context_menu">
+    <label for="context_menu_enabled">Enable</label>
+    <input type="radio" id="context_menu_disabled"
+    name="context_menu">
+    <label for="context_menu_disabled">Disable</label>
+    <br>
+    <small>WARNING: If you choose to disable the context menu this will affect all your browser.</small>
+    <br>
+    <small>HEADS-UP! Please reload your page or strike <kbd>F5</kbd> to make the changes take place. The first time you install the add-on the context menu will be enabled by default.</small>
+    <br>
+    <br>
+    <label>Start Firefox in Kiosk Mode?</label>
+    <br>
+    <br>
+    <input type="radio" id="fullscreen_enabled" name="start_kiosk_mode">
+    <label for="fullscreen_enabled">Enable</label>
+    <input type="radio" id="fullscreen_disabled"
+    name="start_kiosk_mode">
+    <label for="fullscreen_disabled">Disable</label>
+    <br>
+    <small>WARNING: If you choose to enable Firefox startup in Kiosk mode, this will affect the first start of your browser.</small>
+    <br>
+    <small>HEADS-UP! Please close Firefox and start again to make the changes take place. The first time you install this add-on this preference is set to "disable" by default.</small>
+    <br>
+    <br>
+    <header class="panel-section panel-section-header">
+    <div class="icon-section-header"><img src="icons/TopSites.svg"/></div>
+    <div class="text-section-header">Exit Key Combination</div>
+    </header>
+    <br>
+    <p>To exit from the Kiosk mode strike <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>U</kbd> for Windows and Linux. For MAC press <kbd>⌘ Command</kbd> + <kbd>Shift</kbd> + <kbd>U</kbd>.
+       Optionally you can set an optional password. This could be very useful if you find a way (with third party software)
+      to prevent user access to the device's operating system.
+    </p>
+    <br>
+    <label>Enable optional password?</label>
+    <input type="radio" id="password_enabled" name="password">
+    <label for="password_enabled">Enable</label>
+    <input type="radio" id="password_disabled" name="password">
+    <label for="password_disabled">Disable</label>
+    <br>
+    <small>NOTE: Please enable Start Firefox in Kiosk Mode first. This is for security purposes, so that users do not have access to be able to 
+    modify the password.
+    </small>
+  </div>
   <br>
-  <button type="submit" id="save">Save</button>
-  </section>
+  <br>
 
-  <script src="options.js"></script>
+  <button type="submit" id="save" class="browser-style default">Save General Preferences</button>
+
+</form>
+
+<form>
+  <div class="browser-style hide-password">
+    <div class="browser-style">
+      <br>
+      <header class="panel-section panel-section-header">
+      <div class="icon-section-header"><img src="icons/Secure.svg"/></div>
+      <div class="text-section-header">Optional Password</div>
+      </header>
+    </div>
+    <div id="password_not_exist" class="alert browser-style" role="alert">
+    It seems that you have not set a password yet. Please set one?
+    </div>
+    <div id="password_exist" class="alert browser-style" role="alert">
+    You already have a password, do you want to change the existing one?
+    </div>
+    <br>
+    <label for="mk_password">Password</label>
+    <br>
+    <input type="password" id="mk_password" placeholder="Password">
+    <br>
+    <br>
+    <label for="confirm_password">Confirm password</label>
+    <br>
+    <input type="password" id="confirm_password" placeholder="Confirm password">
+    <br>
+    <small>INSECURE PASSWORD WARNING IN FIREFOX: If your APP is not in https (Hypertext Transfer Protocol Secure) then Firefox show this warning.
+    If you have this problem you can solve this in "about:config" turning to "false" the preference 
+    "security.insecure_field_warning.contextual.enabled." As well, you can change "signon.autofillForms.http" preference to disable autofill.
+    Although, we encourage to users to use your APP in https rather than http protocol.
+    </small>
+    <br>
+    <!-- <small>WARNING: Please do not lose your password since this version does not have a way to recover a password (Work in progress)...</small> -->
+  <br>
+  <br>
+  <button type="submit" id="save_password" class="browser-style default">Save Password and General Preferences</button>
+  </div>
+</form>
+
+<script src="mk_utils.js"></script>
+<script src="options.js"></script>
+
 </body>
 
 </html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,34 +1,290 @@
+/**
+ * options.js
+ * @license
+ * This file is part of Modern Kiosk
+ *
+ * Copyright (C) 2018-2019 - RacketLogger
+ * Copyright (C) 2019 - Universidad de El Salvador
+ *
+ * Modern Kiosk is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Modern Kiosk is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Modern Kiosk. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file Option page script. This script manage and save the settings of the
+ * web-extension.
+ * @author Carlos Puchol
+ * @author Hector Castro
+ */
+
+let getURL = document.querySelector("#mk_url");
+let buttonSaveOptions    = document.querySelector("#save");
+let getContextEnable     = document.querySelector("#context_menu_enabled");
+let getContextDisable    = document.querySelector("#context_menu_disabled");
+let getFullscreenEnable  = document.querySelector("#fullscreen_enabled");
+let getFullscreenDisable = document.querySelector("#fullscreen_disabled");
+let getPassWordEnable    = document.querySelector("#password_enabled");
+let getPassWordDisable   = document.querySelector("#password_disabled");
+let getPassAlertExist    = document.querySelector("#password_exist");
+let getPassAlertNotExist = document.querySelector("#password_not_exist");
+let getPassword          = document.querySelector("#mk_password");
+let getPasswordConfirm   = document.querySelector("#confirm_password");
+let dialog = document.querySelector(".hide-password");
+
+/**
+ * Called when user save general preferences settings.
+ * @callback saveOptions
+ * @param {Object} e Object event fired.
+ */
 function saveOptions(e) {
-  browser.storage.local.set({
-    kiosk_url: document.querySelector("#mk_url").value,
-    context_enable: document.querySelector("#context_menu_enabled").checked,
-    context_disable: document.querySelector("#context_menu_disabled").checked,
-    fullscreen_enable: document.querySelector("#fullscreen_enabled").checked,
-    fullscreen_disable: document.querySelector("#fullscreen_disabled").checked
+  let urlIsEmpty = getURL.value;
+  if (!urlIsEmpty) {
+    console.log("URL is empty. Please enter an http or https URL.");
+    e.preventDefault();
+    return;
+  }
+  let mkStorageArea = {
+    kiosk_url: getURL.value,
+    context_enable: getContextEnable.checked,
+    fullscreen_enable: getFullscreenEnable.checked,
+    password_enable: getPassWordEnable.checked
+  }
+  browser.storage.local.set(mkStorageArea);
+  if (!getPassWordEnable.checked) {
+    mkStorageArea = {
+      password_stored: false,
+      password: undefined
+    }
+    browser.storage.local.set(mkStorageArea);
+  }
+  let message = "General preferences saved successfully.";
+  mkNotifications("preferences-notification", message);
+  if (e) { e.preventDefault(); }
+}
+
+/**
+ * Called when user save password.
+ * @callback savePassword
+ * @param {Object} e Object event fired.
+ */
+function savePassword(e) {
+  let message;
+  const getStorage = browser.storage.local.get();
+  getStorage.then((item) => {
+    if (!getPassword.value){
+      message = "Password box is empty. Please enter a password.";
+      mkNotifications("password-notification", message);
+    } else if (!getPasswordConfirm.value) {
+      message = "Confirm password box is empty. Please confirm password.";
+      mkNotifications("confirm-notification", message);
+    } else if (getPassword.value !== getPasswordConfirm.value) {
+      message = "Password box must match with Password confirmation box.";
+      mkNotifications("match-notification", message);
+    } else {
+      if (!item.password_enable) {
+        saveOptions();
+      } else {
+        message = "Password saved successfully.";
+        mkNotifications("save-notification", message);
+      }
+      let mkStorageArea = {
+        password_stored: true,
+        password: getPassword.value
+      }
+      browser.storage.local.set(mkStorageArea);
+
+      // Hide alert about password
+      getPassAlertNotExist.style.display = "none";
+      getPassAlertExist.style.display    = "none";
+    }
   });
   e.preventDefault();
 }
 
+/**
+ * Called when browser reload the options page.
+ * @callback restoreOptions
+ */
 function restoreOptions() {
-  // var storageItem = browser.storage.local.get('kiosk_url');
-  // storageItem.then((res) => {
-  //   document.querySelector("#managed-colour").innerText = res.colour;
-  // });
-
-  var gettingItem = browser.storage.local.get();
-  gettingItem.then((res) => {
-    let getURL = document.querySelector("#mk_url");
-    let getContextEnable     = document.querySelector("#context_menu_enabled");
-    let getContextDisable    = document.querySelector("#context_menu_disabled");
-    let getFullscreenEnable  = document.querySelector("#fullscreen_enabled");
-    let getFullscreenDisable = document.querySelector("#fullscreen_disabled");
+  const getStorage = browser.storage.local.get();
+  getStorage.then((res) => {
+    console.log(`Restoring configuration: ${ res }`);
     getURL.value = res.kiosk_url;
     getContextEnable.checked     = res.context_enable;
-    getContextDisable.checked    = res.context_disable;
+    getContextDisable.checked    = !res.context_enable;
     getFullscreenEnable.checked  = res.fullscreen_enable;
-    getFullscreenDisable.checked = res.fullscreen_disable;
+    getFullscreenDisable.checked = !res.fullscreen_enable;
+    getPassWordEnable.checked    = res.password_enable;
+    getPassWordDisable.checked   = !res.password_enable;
+    // Show if optional password is visible or hidden
+    if (res.password_enable) {
+      dialog.style.display = "block";
+      buttonSaveOptions.disabled = true;
+    } else {
+      dialog.style.display = "none";
+    }
+    // Show alerts about password
+    if (res.password_stored) {
+      getPassAlertExist.style.display    = "block";
+      getPassAlertNotExist.style.display = "none";
+    } else {
+      getPassAlertExist.style.display    = "none";
+      getPassAlertNotExist.style.display = "block";
+    }
+    // Populate password form
+    (!res.password)
+    ? getPassword.value = ""
+    : getPassword.value = res.password;
   });
 }
 
-document.addEventListener('DOMContentLoaded', restoreOptions);
-document.querySelector("#save").addEventListener("click", saveOptions);
+/**
+ * Called when user click on icons (Show, Hide and Cancel) on inputs.
+ * @callback changeIcons
+ * @param {Object} e Object event fired.
+ */
+function changeIcons(e) {
+  let x = e.offsetX;
+  let rectWidth, iconWidth;
+  if (e.target.id === "mk_url") {
+    rectWidth = getURL.getBoundingClientRect().width;
+    iconWidth = rectWidth - 24;
+    if (e.type === "mousedown") {
+      let style = getComputedStyle(getURL);
+      let image = style.backgroundImage;
+      if (
+          (x >= iconWidth && x <= rectWidth) &&
+          (/Cancel.svg"\)$/.test(image))
+      ) {
+        e.target.value="";
+      }
+    }
+  } else if (
+      e.target.id === "mk_password" ||
+      e.target.id === "confirm_password"
+    ) {
+    if (e.target.id === "mk_password" ) {
+      rectWidth = getPassword.getBoundingClientRect().width;
+    } else if (e.target.id === "confirm_password") {
+      rectWidth = getPasswordConfirm.getBoundingClientRect().width;
+    }
+    iconWidth = rectWidth - 24;
+    if (e.type === "click") {
+      let style;
+      if (e.target.id === "mk_password" ) {
+        style = window.getComputedStyle(getPassword);
+      } else if (e.target.id === "confirm_password") {
+        style = window.getComputedStyle(getPasswordConfirm);
+      }
+      let image = style.backgroundImage;
+      if (
+        (x >= iconWidth && x <= rectWidth) &&
+        (/Show.svg"\)$/.test(image))
+      ) {
+        e.target.type = "password";
+        e.target.style.backgroundImage = "url('icons/Hide.svg')";
+      } else if (
+          (x >= iconWidth && x <= rectWidth) &&
+          (/Hide.svg"\)$/.test(image))
+      ) {
+        e.target.type = "text";
+        e.target.style.backgroundImage = "url('icons/Show.svg')";
+      }
+    }
+  }
+  // Control cursor on inputs [text/url/password]
+  if (e.type === "mousemove") {
+    if (x >= iconWidth && x <= rectWidth) {
+      e.target.style.cursor = "pointer";
+    } else {
+      e.target.style.cursor = "auto";
+    }
+  }
+}
+
+/**
+ * Called when user click on "enable optional password" pref.
+ * Show/Hide alert messages: "password_not_exist" and "password_exist"
+ * @callback passVisibilityStatus
+ * @param {Object} e Object event fired.
+ */
+function passVisibilityStatus(e) {
+  if (e.target.id === "password_enabled") {
+    if (!getFullscreenEnable.checked) {
+      getPassWordDisable.checked = true;
+      let message = "Please enable Start Firefox in Kiosk Mode first.\n";
+      message += "The preference was not applied.";
+      mkNotifications("save-notification", message);
+    } else {
+      dialog.style.display = "block";
+      buttonSaveOptions.disabled = true;
+    }
+  } else if (e.target.id === "password_disabled") {
+    dialog.style.display = "none";
+    buttonSaveOptions.disabled = false;
+  } else if (e.target.id === "fullscreen_disabled") {
+    //Preference "password_enable" disabled if the user has enabled it
+    console.log("Preference 'password_enable' disabled");
+    getPassWordDisable.checked = true;
+    dialog.style.display = "none";
+    buttonSaveOptions.disabled = false;
+  }
+}
+
+/**
+ * Event fired when browser reload the options page.
+ * @event document#DOMContentLoaded
+ */
+document.addEventListener("DOMContentLoaded", restoreOptions);
+
+/**
+ * Event fired when user save the settings in the option page.
+ * @event document#click
+ */
+buttonSaveOptions.addEventListener("click", saveOptions);
+
+/**
+ * Event fired when user save the optional password
+ * @event document#click
+ */
+document.querySelector("#save_password")
+  .addEventListener("click", savePassword);
+
+/**
+ * Events fired when user click on input icons: url and passwords
+ * @event document#click
+ * @event document#mousedown
+ * @event document#mousemove
+ */
+//input=>url
+getURL.addEventListener("mousedown", changeIcons);
+getURL.addEventListener("mousemove", changeIcons);
+
+//input=>password
+getPassword.addEventListener("click", changeIcons);
+getPassword.addEventListener("mousemove", changeIcons);
+
+//input=>confirm password
+getPasswordConfirm.addEventListener("click", changeIcons);
+getPasswordConfirm.addEventListener("mousemove", changeIcons);
+
+/**
+ * Events fired when user click on "enable/disable optional password" pref.
+ * @event document#click
+ * @event document#mousedown
+ * @event document#mousemove
+ */
+getPassWordEnable.addEventListener("click", passVisibilityStatus);
+getPassWordDisable.addEventListener("click", passVisibilityStatus);
+getFullscreenDisable.addEventListener("click", passVisibilityStatus);
+


### PR DESCRIPTION
Also this commit add:
* Aligment with Firefox Photon Design and Icons
* Fix some bugs in menus
* Add icons
* Licences
* JSDoc

To test:
- Go to preferences change preferences, password, etc.
- Test Modern Kiosk Mode (fullscreen)
- Test menu in context menu (mouse)
- Disable context menu in preferences
- Test EKC (Ctrl + Shift + U)
- Test to disable password
- Test to change password.

PS.:
- Please see copyright for RacketLogger if not fit, please change in a new commit.
- This will be a legacy version, since firefox --url <url> --kiosk in version 71.0a1 Firefox Nightly
